### PR TITLE
Fix invalid PHPDoc @return this type statements

### DIFF
--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -61,7 +61,7 @@ class Flexible extends Field
      * Set the button's label
      *
      * @param string $label
-     * @return this
+     * @return $this
      */
     public function button($label)
     {
@@ -72,7 +72,7 @@ class Flexible extends Field
      * Set the field's resolver
      *
      * @param string $classname
-     * @return this
+     * @return $this
      */
     public function resolver($classname)
     {
@@ -91,7 +91,7 @@ class Flexible extends Field
      * Register a new layout
      *
      * @param array $arguments
-     * @return this
+     * @return $this
      */
     public function addLayout(...$arguments)
     {
@@ -122,7 +122,7 @@ class Flexible extends Field
      * Apply a field configuration preset
      *
      * @param string $classname
-     * @return this
+     * @return $this
      */
     public function preset($classname)
     {

--- a/src/Http/ScopedRequest.php
+++ b/src/Http/ScopedRequest.php
@@ -25,7 +25,7 @@ class ScopedRequest extends NovaRequest
      *
      * @param  string  $key
      * @param  array  $attributes
-     * @return this
+     * @return $this
      */
     public function scopeInto($key, $attributes)
     {


### PR DESCRIPTION
Fixes methods where PHPDoc @return statements were marked as `this` but should be `$this` instead