### PR TITLE
Apply mutations to attributes before resolving with original fields.

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -137,7 +137,13 @@ class Layout implements LayoutInterface, JsonSerializable
      */
     public function getResolved()
     {
-        return $this->resolve($this->getAttributes());
+        $mutatedAttributes = [];
+
+        foreach ($this->getAttributes() as $key => $value) {
+            $mutatedAttributes[$key] = $this->getAttributeValue($key);
+        }
+
+        return $this->resolve($mutatedAttributes);
     }
 
     /**


### PR DESCRIPTION
After solving the missing Layout->getConnection() problem in #14 , the Date field won't accept the attribute for resolving the value. 

$this->getAttributes() doesn't apply mutations nor casts, therefore the getResolved() function will use the applied mutations and casts for the original field to work properly.

Tested in Laravel 5.7.*

