### PR TITLE
Checking if the $iterable has children with the key attribute

### DIFF
--- a/src/Http/ScopedRequest.php
+++ b/src/Http/ScopedRequest.php
@@ -144,7 +144,7 @@ class ScopedRequest extends NovaRequest
     {
         $keys = array_keys($iterable);
 
-        if (count($keys) !== 3) {
+        if (count($keys) !== 3 || isset($iterable[0]['key'])) {
             return false;
         }
 


### PR DESCRIPTION
Encountered a bug where if I had exactly 3 sub children an error would be returned because it couldn't find the key, this occurred because `isFlexibleStructure` would return the incorrect value.

Added a check for if there is a child of `['key']` on the first child of the `$iterable` if we have exactly 3 keys. This seems to fix issue #56.