### PR TITLE
Start work on deleting an image field within flexible content

### DIFF
--- a/src/Collections/FieldCollection.php
+++ b/src/Collections/FieldCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Whitecube\NovaFlexibleContent\Collections;
+
+use Laravel\Nova\Fields\FieldCollection as NovaFieldCollection;
+
+class FieldCollection extends NovaFieldCollection
+{
+    /**
+     * Find a given field by its attribute.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $default
+     * @return \Laravel\Nova\Fields\Field|null
+     */
+    public function findFieldByAttribute($attribute, $default = null)
+    {
+        $array = explode("__", $attribute);
+        if (isset($array[1])) {
+            $attribute = $array[1];
+        }
+        return $this->first(function ($field) use ($attribute) {
+            return isset($field->attribute) &&
+                $field->attribute == $attribute;
+        }, $default);
+    }
+}

--- a/src/Traits/AvailableFields.php
+++ b/src/Traits/AvailableFields.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Whitecube\NovaFlexibleContent\Traits;
+
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Whitecube\NovaFlexibleContent\Collections\FieldCollection;
+use Whitecube\NovaFlexibleContent\Flexible;
+
+trait AvailableFields
+{
+
+    /**
+     * Get the fields that are available for the given request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @return \Laravel\Nova\Fields\FieldCollection
+     */
+    public function availableFields(NovaRequest $request)
+    {
+        if ($request->method() === "DELETE") {
+            $fields = $this->fields($request);
+            $flattened = [];
+
+            foreach ($fields as $field) {
+                if ($field instanceof Flexible) {
+                    $flattened = array_merge($flattened, $this->flattenFlexibleField($field));
+                } else {
+                    $flattened[] = $field;
+                }
+            }
+        } else {
+            $flattened = $this->fields($request);
+        }
+
+        return new FieldCollection(array_values($this->filter($flattened)));
+    }
+
+    /**
+     * Flatten the fields
+     *
+     * @param Flexible $field
+     * @return array
+     */
+    private function flattenFlexibleField($field)
+    {
+        $flattened = [];
+        foreach ($field->layouts() as $layout) {
+            foreach ($layout->fields() as $field) {
+                if ($field instanceof Flexible) {
+                    $flattened = array_merge($flattened, $this->flattenFlexibleField($field));
+                } else {
+                    $flattened[] = $field;
+                }
+            }
+        }
+
+        return $flattened;
+    }
+}


### PR DESCRIPTION
Was able to flatten the fields on a DELETE request only to overcome finding the field in `FieldDestroyController`.

After that - the query to update fails.

To use, add the `AvailableFields` trait to your resource.