### PR TITLE
Allow user to pass in pre-initialized layout object to addLayout

### DIFF
--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -160,7 +160,10 @@ class Flexible extends Field
         }
 
         $layout = $arguments[0];
-        $layout = new $layout();
+
+        if(!($layout instanceof LayoutInterface)) {
+            $layout = new $layout();
+        }
 
         if(!($layout instanceof LayoutInterface)) {
             throw new \Exception('Layout Class "' . get_class($layout) . '" does not implement LayoutInterface.');
@@ -433,7 +436,7 @@ class Flexible extends Field
             // reference (see Http\TransformsFlexibleErrors).
             static::registerValidationKeys($rules);
 
-            // Then, transform the rules into an array that's actually 
+            // Then, transform the rules into an array that's actually
             // usable by Laravel's Validator.
             $rules = $this->getCleanedRules($rules);
         }


### PR DESCRIPTION
As well as allowing the user to pass in multiple arguments to the addLayout function, and the layout class name as a string, allow the user to pass in a single argument of a pre-initialized layout object.