### PR TITLE
Added resource to DetailGroup Component.

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -6,6 +6,9 @@
                     :index="index"
                     :last="(index === groups.length - 1)"
                     :group="group"
+                    :resource="resource"
+                    :resourceName="resourceName"
+                    :resourceId="resourceId"
                 />
             </div>
         </template>

--- a/resources/js/components/DetailGroup.vue
+++ b/resources/js/components/DetailGroup.vue
@@ -23,7 +23,7 @@
 
 <script>
 export default {
-    props: ['group', 'index', 'last'],
+    props: ['group', 'index', 'last', 'resource', 'resourceName', 'resourceId'],
 
     computed: {
         componentStyle() {


### PR DESCRIPTION
@voidgraphics Since for an important project I really need my reported [issue](https://github.com/whitecube/nova-flexible-content/issues/113) resolved, I started to do some research and debugging. I could not identify the issue yet, but found **one part** of the problem with File fields (based on a already open [PR](https://github.com/whitecube/nova-flexible-content/pull/108)). At the moment it is not possible to download files in the detail view when they are used inside a flexible content. This is partly caused by the fact that the DetailGroup component did not receive the resourceName and resourceId until now. So the download-link was /undefined/undefined/... and subsequently Nova's _FieldDownloadController_ did not find the resource.
_Note: If you combine these small changes with the findFieldByAttribute implementation from the PR I mentioned above, hopefully the whole issue with the File field could be resolved._