### PR TITLE
Scope flexible-search-menu's multiselect field SCSS (fix #137)

### DIFF
--- a/resources/js/components/SearchMenu.vue
+++ b/resources/js/components/SearchMenu.vue
@@ -15,7 +15,7 @@
             </div>
             <div class="w-4/5">
                 <div v-if="layouts.length > 1" style="min-width: 300px;">
-                        <div>
+                        <div class="flexible-search-menu-multiselect">
                             <multiselect v-model="selectedLayout" :options="layouts"
                                          :custom-label="renderLayoutName"
                                          :placeholder="field.button"

--- a/resources/sass/multiselect.scss
+++ b/resources/sass/multiselect.scss
@@ -1,327 +1,333 @@
-$multiselect-primary-color: #41B883 !default;
-$multiselect-primary-color-dark: darken(#41B883, 20%) !default;
-$mulitselect-secondary-color: white !default;
-$mulitselect-secondary-hover-color: #e8e8e8 !default;
-$mulitselect-secondary-hover-color-10: darken(#e8e8e8, 10%) !default;
-$mulitselect-secondary-hover-color-25: darken(#e8e8e8, 25%) !default;
-$multiselect-text-color: #35495e !default;
-$multiselect-border-color: #999999 !default;
-$multiselect-placeholder-color: #adadad !default;
-$multiselect-selected-background: #f3f3f3 !default;
-$multiselect-radius: .3125rem !default;
-
-.multiselect__spinner {
-    position: absolute;
-    right: 1px;
-    top: 1px;
-    width: 3rem;
-    height: 2.1875rem;
-    background: $mulitselect-secondary-color;
-    display: block;
-    &:before,
-    &:after {
+.flexible-search-menu-multiselect {
+    $multiselect-primary-color: #41b883 !default;
+    $multiselect-primary-color-dark: darken(#41b883, 20%) !default;
+    $mulitselect-secondary-color: white !default;
+    $mulitselect-secondary-hover-color: #e8e8e8 !default;
+    $mulitselect-secondary-hover-color-10: darken(#e8e8e8, 10%) !default;
+    $mulitselect-secondary-hover-color-25: darken(#e8e8e8, 25%) !default;
+    $multiselect-text-color: #35495e !default;
+    $multiselect-border-color: #999999 !default;
+    $multiselect-placeholder-color: #adadad !default;
+    $multiselect-selected-background: #f3f3f3 !default;
+    $multiselect-radius: 0.3125rem !default;
+    
+    .multiselect__spinner {
         position: absolute;
-        content: "";
-        top: 50%;
-        left: 50%;
-        margin: 0.875rem 0 0 0.875rem;
-        width: 1rem;
-        height: 1rem;
-        border-radius: 100%;
-        border-color: $multiselect-primary-color transparent transparent;
-        border-style: solid;
-        border-width: 2px;
-        box-shadow: 0 0 0 1px transparent;
-}
-    &:before {
-        animation: spinning 2.4s cubic-bezier(0.41, 0.26, 0.2, 0.62);
-        animation-iteration-count: infinite;
-}
-    &:after {
-        animation: spinning 2.4s cubic-bezier(0.51, 0.09, 0.21, 0.8);
-        animation-iteration-count: infinite;
-}
-}
-
-.multiselect__loading-transition {
-    transition: opacity 0.4s ease-in-out;
-    opacity: 1;
-}
-
-.multiselect__loading-enter,
-.multiselect__loading-leave {
-    opacity: 0;
-}
-
-.multiselect,
-.multiselect__input,
-.multiselect__single {
-    font: {
-        family: inherit;
-        size: 0.875rem;
-        weight: lighter;
-};
-}
-
-.multiselect {
-    box-sizing: content-box;
-    * {
-        box-sizing: border-box;
-}
-    display: block;
-    position: relative;
-    width: 100%;
-    min-height: 2.5rem;
-    text-align: left;
-    color: $multiselect-text-color;
-    &:focus {
-        outline: none;
-}
-    &--active {
-        z-index: 50;
-        .multiselect__current,
-        .multiselect__input,
-        .multiselect__tags {
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
-    }
-        .multiselect__select {
-            transform: rotateZ(180deg);
-    }
-}
-}
-
-.multiselect__input,
-.multiselect__single {
-    position: relative;
-    display: inline-block;
-    min-height: 1.25rem;
-    line-height: 1.25rem;
-    border: none;
-    border-radius: $multiselect-radius;
-    background: $mulitselect-secondary-color;
-    padding: 1px 0 0 $multiselect-radius;
-    width: auto;
-    transition: border 0.1s ease;
-    box-sizing: border-box;
-    margin-bottom: 0.5rem;
-    &:hover {
-        border-color: $mulitselect-secondary-hover-color-10;
-}
-    &:focus {
-        border-color: $mulitselect-secondary-hover-color-25;
-        outline: none;
-}
-}
-
-.multiselect__single {
-    padding-left: 0.375rem;
-    margin-bottom: 0.5rem;
-}
-
-.multiselect__tags {
-    min-height: 2.5rem;
-    display: block;
-    padding: 0.5rem 2.5rem 0 0.5rem;
-    border-radius: $multiselect-radius;
-    border: 1px solid $mulitselect-secondary-hover-color;
-    background: $mulitselect-secondary-color;
-}
-
-.multiselect__tag {
-    position: relative;
-    display: inline-block;
-    padding: 0.25rem 1.625rem 0.25rem 0.625rem;
-    border-radius: $multiselect-radius;
-    margin-right: 0.625rem;
-    color: $mulitselect-secondary-color;
-    line-height: 1;
-    background: $multiselect-primary-color;
-    margin-bottom: 0.5rem;
-}
-
-.multiselect__tag-icon {
-    cursor: pointer;
-    margin-left: 7px;
-    position: absolute;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    font: {
-        weight: 700;
-        style: initial;
-};
-    width: 1.375rem;
-    text-align: center;
-    line-height: 1.375rem;
-    transition: all 0.2s ease;
-    border-radius: $multiselect-radius;
-    &:after {
-        content: "\00D7";
-        color: $multiselect-primary-color-dark;
-        font-size: 0.875rem;
-}
-    &:focus, &:hover {
-        background: $multiselect-primary-color-dark;
+        right: 1px;
+        top: 1px;
+        width: 3rem;
+        height: 2.1875rem;
+        background: $mulitselect-secondary-color;
+        display: block;
+        &:before,
         &:after {
-            color: $mulitselect-secondary-color;
+            position: absolute;
+            content: "";
+            top: 50%;
+            left: 50%;
+            margin: 0.875rem 0 0 0.875rem;
+            width: 1rem;
+            height: 1rem;
+            border-radius: 100%;
+            border-color: $multiselect-primary-color transparent transparent;
+            border-style: solid;
+            border-width: 2px;
+            box-shadow: 0 0 0 1px transparent;
+        }
+        &:before {
+            animation: spinning 2.4s cubic-bezier(0.41, 0.26, 0.2, 0.62);
+            animation-iteration-count: infinite;
+        }
+        &:after {
+            animation: spinning 2.4s cubic-bezier(0.51, 0.09, 0.21, 0.8);
+            animation-iteration-count: infinite;
+        }
     }
-}
-}
-
-.multiselect__current {
-    line-height: 1rem;
-    min-height: 2.5rem;
-    box-sizing: border-box;
-    display: block;
-    overflow: hidden;
-    padding: 0.5rem 0.75rem 0;
-    padding-right: 1.875rem;
-    white-space: nowrap;
-    margin: 0;
-    text-decoration: none;
-    border-radius: $multiselect-radius;
-    border: 1px solid $mulitselect-secondary-hover-color;
-    cursor: pointer;
-}
-
-.multiselect__select {
-    line-height: 1rem;
-    display: block;
-    position: absolute;
-    box-sizing: border-box;
-    width: 2.5rem;
-    height: 2.375rem;
-    right: 1px;
-    top: 1px;
-    padding: 0.25rem 0.5rem;
-    margin: 0;
-    text-decoration: none;
-    text-align: center;
-    cursor: pointer;
-    transition: transform 0.2s ease;
-    &:before {
+    
+    .multiselect__loading-transition {
+        transition: opacity 0.4s ease-in-out;
+        opacity: 1;
+    }
+    
+    .multiselect__loading-enter,
+    .multiselect__loading-leave {
+        opacity: 0;
+    }
+    
+    .multiselect,
+    .multiselect__input,
+    .multiselect__single {
+        font: {
+            family: inherit;
+            size: 0.875rem;
+            weight: lighter;
+        }
+    }
+    
+    .multiselect {
+        box-sizing: content-box;
+        * {
+            box-sizing: border-box;
+        }
+        display: block;
         position: relative;
-        right: 0;
-        top: 65%;
-        color: #999999;
-        margin-top: 0.25rem;
-        border-style: solid;
-        border-width: $multiselect-radius $multiselect-radius 0 $multiselect-radius;
-        border-color: $multiselect-border-color transparent transparent transparent;
-        content: "";
-}
-}
-
-.multiselect__placeholder {
-    color: $multiselect-placeholder-color;
-    display: inline-block;
-    margin-bottom: 0.625rem;
-    padding-top: 0.125rem;
-    .multiselect--active & {
-        display: none;
-}
-}
-
-.multiselect__content {
-    position: absolute;
-    list-style: none;
-    display: block;
-    background: $mulitselect-secondary-color;
-    width: 100%;
-    max-height: 15rem;
-    overflow: auto;
-    padding: 0;
-    margin: 0;
-    border: 1px solid $mulitselect-secondary-hover-color;
-    border-top: none;
-    border-bottom-left-radius: $multiselect-radius;
-    border-bottom-right-radius: $multiselect-radius;
-    z-index: 50;
-    &::webkit-scrollbar {
-        display: none;
-}
-}
-
-.multiselect__option {
-    display: block;
-    padding: 0.75rem;
-    min-height: 2.5rem;
-    line-height: 1rem;
-    font-weight: 300;
-    text-decoration: none;
-    text-transform: none;
-    vertical-align: middle;
-    position: relative;
-    cursor: pointer;
-    &:after {
-        top: 0;
-        right: 0;
-        position: absolute;
-        line-height: 2.5rem;
-        padding-right: 0.75rem;
-        padding-left: 1.25rem;
-}
-    &--highlight {
-        background: $multiselect-primary-color;
-        outline: none;
-        color: white;
-        &:after {
-            content: attr(data-select);
-            color: white;
-    }
-}
-    &--selected {
-        background: $multiselect-selected-background;
+        width: 100%;
+        min-height: 2.5rem;
+        text-align: left;
         color: $multiselect-text-color;
-        font-weight: bold;
-        &:after {
-            content: attr(data-selected);
-            font-weight: 300;
-            color: darken($multiselect-selected-background, 20%);
+        &:focus {
+            outline: none;
+        }
+        &--active {
+            z-index: 50;
+            .multiselect__current,
+            .multiselect__input,
+            .multiselect__tags {
+                border-bottom-left-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+            .multiselect__select {
+                transform: rotateZ(180deg);
+            }
+        }
     }
-}
-}
-
-.multiselect__option--selected.multiselect__option--highlight {
-    background: #ff6a6a;
-    color: $mulitselect-secondary-color;
-    font-weight: lighter;
-    &:after {
-        content: attr(data-deselect);
+    
+    .multiselect__input,
+    .multiselect__single {
+        position: relative;
+        display: inline-block;
+        min-height: 1.25rem;
+        line-height: 1.25rem;
+        border: none;
+        border-radius: $multiselect-radius;
+        background: $mulitselect-secondary-color;
+        padding: 1px 0 0 $multiselect-radius;
+        width: auto;
+        transition: border 0.1s ease;
+        box-sizing: border-box;
+        margin-bottom: 0.5rem;
+        &:hover {
+            border-color: $mulitselect-secondary-hover-color-10;
+        }
+        &:focus {
+            border-color: $mulitselect-secondary-hover-color-25;
+            outline: none;
+        }
+    }
+    
+    .multiselect__single {
+        padding-left: 0.375rem;
+        margin-bottom: 0.5rem;
+    }
+    
+    .multiselect__tags {
+        min-height: 2.5rem;
+        display: block;
+        padding: 0.5rem 2.5rem 0 0.5rem;
+        border-radius: $multiselect-radius;
+        border: 1px solid $mulitselect-secondary-hover-color;
+        background: $mulitselect-secondary-color;
+    }
+    
+    .multiselect__tag {
+        position: relative;
+        display: inline-block;
+        padding: 0.25rem 1.625rem 0.25rem 0.625rem;
+        border-radius: $multiselect-radius;
+        margin-right: 0.625rem;
         color: $mulitselect-secondary-color;
-}
-}
-
-.multiselect--disabled {
-    background: darken($mulitselect-secondary-color, 7%);
-    pointer-events: none;
-    .multiselect__current,
+        line-height: 1;
+        background: $multiselect-primary-color;
+        margin-bottom: 0.5rem;
+    }
+    
+    .multiselect__tag-icon {
+        cursor: pointer;
+        margin-left: 7px;
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        font: {
+            weight: 700;
+            style: initial;
+        }
+        width: 1.375rem;
+        text-align: center;
+        line-height: 1.375rem;
+        transition: all 0.2s ease;
+        border-radius: $multiselect-radius;
+        &:after {
+            content: "\00D7";
+            color: $multiselect-primary-color-dark;
+            font-size: 0.875rem;
+        }
+        &:focus,
+        &:hover {
+            background: $multiselect-primary-color-dark;
+            &:after {
+                color: $mulitselect-secondary-color;
+            }
+        }
+    }
+    
+    .multiselect__current {
+        line-height: 1rem;
+        min-height: 2.5rem;
+        box-sizing: border-box;
+        display: block;
+        overflow: hidden;
+        padding: 0.5rem 0.75rem 0;
+        padding-right: 1.875rem;
+        white-space: nowrap;
+        margin: 0;
+        text-decoration: none;
+        border-radius: $multiselect-radius;
+        border: 1px solid $mulitselect-secondary-hover-color;
+        cursor: pointer;
+    }
+    
     .multiselect__select {
+        line-height: 1rem;
+        display: block;
+        position: absolute;
+        box-sizing: border-box;
+        width: 2.5rem;
+        height: 2.375rem;
+        right: 1px;
+        top: 1px;
+        padding: 0.25rem 0.5rem;
+        margin: 0;
+        text-decoration: none;
+        text-align: center;
+        cursor: pointer;
+        transition: transform 0.2s ease;
+        &:before {
+            position: relative;
+            right: 0;
+            top: 65%;
+            color: #999999;
+            margin-top: 0.25rem;
+            border-style: solid;
+            border-width: $multiselect-radius $multiselect-radius 0
+            $multiselect-radius;
+            border-color: $multiselect-border-color transparent transparent
+            transparent;
+            content: "";
+        }
+    }
+    
+    .multiselect__placeholder {
+        color: $multiselect-placeholder-color;
+        display: inline-block;
+        margin-bottom: 0.625rem;
+        padding-top: 0.125rem;
+        .multiselect--active & {
+            display: none;
+        }
+    }
+    
+    .multiselect__content {
+        position: absolute;
+        list-style: none;
+        display: block;
+        background: $mulitselect-secondary-color;
+        width: 100%;
+        max-height: 15rem;
+        overflow: auto;
+        padding: 0;
+        margin: 0;
+        border: 1px solid $mulitselect-secondary-hover-color;
+        border-top: none;
+        border-bottom-left-radius: $multiselect-radius;
+        border-bottom-right-radius: $multiselect-radius;
+        z-index: 50;
+        &::webkit-scrollbar {
+            display: none;
+        }
+    }
+    
+    .multiselect__option {
+        display: block;
+        padding: 0.75rem;
+        min-height: 2.5rem;
+        line-height: 1rem;
+        font-weight: 300;
+        text-decoration: none;
+        text-transform: none;
+        vertical-align: middle;
+        position: relative;
+        cursor: pointer;
+        &:after {
+            top: 0;
+            right: 0;
+            position: absolute;
+            line-height: 2.5rem;
+            padding-right: 0.75rem;
+            padding-left: 1.25rem;
+        }
+        &--highlight {
+            background: $multiselect-primary-color;
+            outline: none;
+            color: white;
+            &:after {
+                content: attr(data-select);
+                color: white;
+            }
+        }
+        &--selected {
+            background: $multiselect-selected-background;
+            color: $multiselect-text-color;
+            font-weight: bold;
+            &:after {
+                content: attr(data-selected);
+                font-weight: 300;
+                color: darken($multiselect-selected-background, 20%);
+            }
+        }
+    }
+    
+    .multiselect__option--selected.multiselect__option--highlight {
+        background: #ff6a6a;
+        color: $mulitselect-secondary-color;
+        font-weight: lighter;
+        &:after {
+            content: attr(data-deselect);
+            color: $mulitselect-secondary-color;
+        }
+    }
+    
+    .multiselect--disabled {
+        background: darken($mulitselect-secondary-color, 7%);
+        pointer-events: none;
+        .multiselect__current,
+        .multiselect__select {
+            background: darken($mulitselect-secondary-color, 7%);
+            color: darken($mulitselect-secondary-color, 35%);
+        }
+    }
+    
+    .multiselect__option--disabled {
         background: darken($mulitselect-secondary-color, 7%);
         color: darken($mulitselect-secondary-color, 35%);
-}
-}
-
-.multiselect__option--disabled {
-    background: darken($mulitselect-secondary-color, 7%);
-    color: darken($mulitselect-secondary-color, 35%);
-    cursor: text;
-    pointer-events: none;
-    &:visited {
-        color: darken($mulitselect-secondary-color, 35%);
-}
-    &:hover,
-    &:focus {
-        background: $multiselect-primary-color-dark;
-}
-}
-
-.multiselect-transition {
-    transition: all 0.3s ease;
-}
-
-.multiselect-enter, .multiselect-leave {
-    opacity: 0;
-    max-height: 0 !important;
+        cursor: text;
+        pointer-events: none;
+        &:visited {
+            color: darken($mulitselect-secondary-color, 35%);
+        }
+        &:hover,
+        &:focus {
+            background: $multiselect-primary-color-dark;
+        }
+    }
+    
+    .multiselect-transition {
+        transition: all 0.3s ease;
+    }
+    
+    .multiselect-enter,
+    .multiselect-leave {
+        opacity: 0;
+        max-height: 0 !important;
+    }
 }


### PR DESCRIPTION
Put the `vue-multiselect` in the `flexible-search-menu` inside a div with the class `flexible-search-menu-multiselect` and then wrapped the SCSS in the `multiselect.scss` in a `.flexible-search-menu-multiselect` selector to avoid leaking the multiselect styles all across the Laravel Nova instance. Now they only apply to the multiselect field inside `flexible-search-menu`. This fixes #137  and provides support for `nova-multiselect-field`.