### PR TITLE
Fix relative namespace in phpDoc

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -14,7 +14,7 @@ trait HasFlexible {
      *
      * @param string $attribute
      * @param array  $layoutMapping
-     * @return Whitecube\NovaFlexibleContent\Layouts\Collection
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Collection
      */
     public function flexible($attribute, $layoutMapping = [])
     {
@@ -32,7 +32,7 @@ trait HasFlexible {
      *
      * @param mixed $value
      * @param array $layoutMapping
-     * @return Whitecube\NovaFlexibleContent\Layouts\Collection
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Collection
      */
     public function toFlexible($value, $layoutMapping = [])
     {
@@ -132,7 +132,7 @@ trait HasFlexible {
      * @param string $key
      * @param array  $attributes
      * @param array  $layoutMapping
-     * @return Whitecube\NovaFlexibleContent\Layouts\LayoutInterface
+     * @return \Whitecube\NovaFlexibleContent\Layouts\LayoutInterface
      */
     protected function createMappedLayout($name, $key, $attributes, array $layoutMapping)
     {

--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -395,7 +395,7 @@ class Flexible extends Field
      * Find an existing group based on its key
      *
      * @param  string $key
-     * @return Whitecube\NovaFlexibleContent\Layouts\Layout
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Layout
      */
     protected function findGroup($key)
     {
@@ -409,7 +409,7 @@ class Flexible extends Field
      *
      * @param  string $layout
      * @param  string $key
-     * @return Whitecube\NovaFlexibleContent\Layouts\Layout
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Layout
      */
     protected function newGroup($layout, $key)
     {

--- a/src/Http/ScopedRequest.php
+++ b/src/Http/ScopedRequest.php
@@ -13,7 +13,7 @@ class ScopedRequest extends NovaRequest
      * @param  \Laravel\Nova\Http\Requests\NovaRequest  $from
      * @param  array  $attributes
      * @param  string  $group
-     * @return Whitecube\NovaFlexibleContent\Http\ScopedRequest
+     * @return \Whitecube\NovaFlexibleContent\Http\ScopedRequest
      */
     public static function scopeFrom(NovaRequest $from, $attributes, $group)
     {

--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -171,7 +171,7 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
      * Get an empty cloned instance
      *
      * @param  string  $key
-     * @return Whitecube\NovaFlexibleContent\Layouts\Layout
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Layout
      */
     public function duplicate($key)
     {
@@ -183,7 +183,7 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
      *
      * @param  string  $key
      * @param  array  $attributes
-     * @return Whitecube\NovaFlexibleContent\Layouts\Layout
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Layout
      */
     public function duplicateAndHydrate($key, array $attributes = [])
     {


### PR DESCRIPTION
For proper autocomplete. If the namespaces are relative, it can't be read correctly so it expands to ~~`\Whitecube\NovaFlexibleContent\Concerns`~~`\Whitecube\NovaFlexibleContent\Layouts\Collection` instead of just `\Whitecube\NovaFlexibleContent\Layouts\Collection` 