### PR TITLE
Prevent creating a loop between model and trait.

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -18,7 +18,7 @@ trait HasFlexible {
      */
     public function flexible($attribute, $layoutMapping = [])
     {
-        $flexible = data_get($this, $attribute);
+        $flexible = data_get($this->attributes, $attribute);
 
         if(app()->getProvider(NovaServiceProvider::class)) {
             return $flexible;


### PR DESCRIPTION
Changes:
Get the raw attributes data using the "attributes" property to prevent creating a loop.

Heres an example that will create a loop:

1. We call "flexible()" when accessing the "pages" property.
2. The "flexible()" method tries to get "pages" property directly from model,
                which means "getPagesAttribute()" will be called again.

```
public function getPagesAttribute()
{
    return $this->flexible('pages', ...);
}
```