### PR TITLE
Import Collection

### DIFF
--- a/src/Value/Resolver.php
+++ b/src/Value/Resolver.php
@@ -2,6 +2,8 @@
 
 namespace Whitecube\NovaFlexibleContent\Value;
 
+use Illuminate\Support\Collection;
+
 class Resolver implements ResolverInterface
 {
 


### PR DESCRIPTION
In #49, a check was added to support casting the flexible attribute to a
collection, in your Eloquent model. However, this check didn't actually
work as intended because the Collection class wasn't imported.