### PR TITLE
Translate the attribute if the translation exists

### DIFF
--- a/src/Http/TransformsFlexibleErrors.php
+++ b/src/Http/TransformsFlexibleErrors.php
@@ -91,6 +91,10 @@ trait TransformsFlexibleErrors
         $search = str_replace('_', ' ', Str::snake($key));
         $attribute = str_replace('_', ' ', Str::snake($attribute->name));
 
+        if(!Str::startsWith($translated = trans('validation.attributes.'.$attribute), 'validation.attributes.')) {
+            $attribute = $translated;
+        }
+
         return array_map(function($message) use ($search, $attribute) {
             return str_replace(
                 [$search, Str::upper($search), Str::ucfirst($search)], 

--- a/src/Http/TransformsFlexibleErrors.php
+++ b/src/Http/TransformsFlexibleErrors.php
@@ -2,6 +2,7 @@
 
 namespace Whitecube\NovaFlexibleContent\Http;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Whitecube\NovaFlexibleContent\Flexible;
 use Illuminate\Http\JsonResponse;
@@ -91,8 +92,9 @@ trait TransformsFlexibleErrors
         $search = str_replace('_', ' ', Str::snake($key));
         $attribute = str_replace('_', ' ', Str::snake($attribute->name));
 
-        if(!Str::startsWith($translated = trans('validation.attributes.'.$attribute), 'validation.attributes.')) {
-            $attribute = $translated;
+        // We translate the attribute if it exists
+        if(Lang::has('validation.attributes.'.$attribute)) {
+            $attribute = trans('validation.attributes.'.$attribute);
         }
 
         return array_map(function($message) use ($search, $attribute) {


### PR DESCRIPTION
Right now, the attributes are not translated from the validation file.
=> See the "title", "video" and "content"

![screen_1](https://user-images.githubusercontent.com/12152071/84175603-7c875080-aa80-11ea-8961-35ef5ac63022.png)

With this attributes will be translated if the translation is set in validation.attributes. (example using the french locale)
=> "title" become "titre"
=> "video" become "vidéo"
=> "content" become "contenu"

![screen_2](https://user-images.githubusercontent.com/12152071/84175699-a0e32d00-aa80-11ea-92f9-01b3904762b5.png)
