### PR TITLE
Ensure flexible fields are casted in testing environment

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -33,7 +33,7 @@ trait HasFlexible {
      */
     public function cast($value, $layoutMapping = [])
     {
-        if(app()->getProvider(NovaServiceProvider::class)) {
+        if(app()->getProvider(NovaServiceProvider::class) && !app()->environment('testing')) {
             return $value;
         }
 


### PR DESCRIPTION
This PR makes sure flexible content casting is not skipped when using this package in testing environment. Refer to #169 for more information.

**In short**
Previously the `cast` method only checked if the NovaServiceProvider was registered in order to determine if the values needed to be cast to a flexible collection.

Nova always registers the NovaServiceProvider when running in console. This caused the cast method to never actually cast the value when running PHPUnit.

This PR adds an additional check to determine if the app is running in `testing` environment to circumvent this issue.