### PR TITLE
Fix MediaLibrary integration

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -131,7 +131,7 @@ trait HasFlexible {
             $attributes = $item->getAttributes();
         }
 
-        if(is_null($name) || !$attributes) {
+        if(is_null($name)) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes the integration with the MediaLibrary.

When the layout has a single `Images` field there are no attributes:
```json
[{"key": "gCnp7d2OpddfWoMU", "layout": "gallerylayout", "attributes": []}]
```

And this `!$attritubes` check prevents such layout from the correct mapping.
