### PR TITLE
Require laravel nova ^3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "laravel/nova": "^3.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Require laravel nova >=3.2.0 for method FieldCollection::filterForDetail to work