### PR TITLE
fix class checks with Media class

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -85,7 +85,7 @@ trait HasMediaLibrary {
     public function resolveForDisplay(array $attributes = [])
     {
         $this->fields->each(function ($field) use ($attributes) {
-            if(is_subclass_of($field, Media::class)) {
+            if(is_a($field, Media::class)) {
                 $field->resolveForDisplay($this->getMediaModel(), $field->attribute . $this->getSuffix());
             } else {
                 $field->resolveForDisplay($attributes);


### PR DESCRIPTION
To solve `Call to a member function getMedia() on array`.

should use `is_a` instead of `is_subclass_of` for class checks.

it will always return false with `is_subclass_of` by check the field class. because the `$field` is not a subclass of `Ebess\AdvancedNovaMediaLibrary\Fields\Media`.