### PR TITLE
Filter falsey values from collection

### DIFF
--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -346,7 +346,7 @@ class Flexible extends Field
             $callbacks = array_merge($callbacks, $group->fill($scope));
 
             return $group;
-        });
+        })->filter();
 
         $this->fireRemoveCallbacks($new_groups);
 


### PR DESCRIPTION
This ensures the collection of groups doesn't contain false or corrupt values.

I'm using this package together with the [Nova Dependency Container](https://novapackages.com/packages/epartment/nova-dependency-container), in the following way:

```
            NovaDependencyContainer::make([
                Flexible::make('Sliding cards', 'content')
                    ->fullWidth()
                    ->addLayout('Sliding cards', 'sliding_cards', [
                        Flexible::make('Sliding cards')
                            ->fullWidth()
                            ->button('Voeg kaart toe')
                            ->addLayout('Kaart', 'card', [
                                Text::make('Titel van de kaart'),
                                Text::make('Plaatje'),
                                Text::make('Kort tekstje erbij'),
                            ]),
                    ])
                    ->limit(1),
            ])->dependsOn('type', StickyStoryModel::SLIDING_CARDS),
            NovaDependencyContainer::make([
                Flexible::make('Video', 'content')
                    ->fullWidth()
                    ->addLayout(StickyStoryVideo::class)
                    ->limit(1),
            ])->dependsOn('type', StickyStoryModel::VIDEO),
```

Without the proposed change, I get an exception saying `Call to a member function inUseKey() on null` in `Flexible.php` on line 365. 
This is because the collection in `syncAndFillGroups` contains a `NULL` value instead of a group. 

It's an edge-case, but it would help me immensely if the `filter()` call could be added! 
I don't think there are unwanted side-effects, since you would never expect there to be a `NULL`, or otherwise falsey value, in this collection in normal scenarios.

Please let me know what you think.