### PR TITLE
Fix undefined property 'attributes'

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -123,7 +123,7 @@ trait HasFlexible {
         elseif(is_a($item, \stdClass::class)) {
             $name = $item->layout ?? null;
             $key = $item->key ?? null;
-            $attributes = (array) $item->attributes ?? [];
+            $attributes = (array) ($item->attributes ?? []);
         }
         elseif(is_a($item, Layout::class)) {
             $name = $item->name();


### PR DESCRIPTION
That casting operator is greedy. Therefore it will cast `$item->attributes` into an array, and only _afterwards_ tack on the `?? []` operation. 
So this _might_ throw an ErrorException if the object doesn't support an `attributes` property: `Undefined property: stdClass::$attributes`.

Adding some parentheses fixes this.