### PR TITLE
Preserve model when duplicating layout

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -223,13 +223,17 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
             return $this->cloneField($field);
         });
         
-        return new static(
+        $clone = new static(
             $this->title,
             $this->name,
             $fields,
             $key,
             $attributes
         );
+        if (!is_null($this->model)) {
+            $clone->setModel($this->model);
+        }
+        return $clone;
     }
 
     /**


### PR DESCRIPTION
I ran into some trouble where "Origin HasMedia model not found.", even though I explicitly called `setModel()`.

It turns out this was because the model property is not preserved when duplicating the Layout. 

I'm not entirely sure if this aligns with your idea for this property, so let me know if this is actually unwanted behavior. 
Come to think of it: I'm not yet sure why this duplication is necessary. Maybe you can enlighten me? 🙂 