### PR TITLE
Add PHPUnit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+
+jobs:
+  tests:
+    name: PHPUnit
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        php: [7.2, 7.4, 8]
+        prefer: ['--prefer-lowest', '--prefer-stable']
+
+    steps:
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install PHP dependencies
+        run: |
+          composer config --ansi -- http-basic.nova.laravel.com ${{ secrets.NOVA_USERNAME }} ${{ secrets.NOVA_PASSWORD }}
+          composer update ${{ matrix.prefer }} --prefer-dist --no-interaction --no-suggest --ansi
+
+      - name: PHPUnit
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ Feel free to suggest changes, ask for new features or fix bugs yourself. We're s
 
 Thanks!
 
+### Unit tests
+
+To ensure your change keeps working add an unit test. The current set of tests is limited, but every unit test added wil improve the quality of the package.
+
+Run PHPUnit by calling `composer test`.
+
 ## Made with ❤️ for open source
 
 At [Whitecube](https://www.whitecube.be) we use a lot of open source software as part of our daily work.

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,26 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": "^3.2"
+        "php": ">=7.2.5",
+        "laravel/nova": "^3.2",
+        "laravel/framework": "^7.0"
     },
     "autoload": {
         "psr-4": {
             "Whitecube\\NovaFlexibleContent\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://nova.laravel.com"
+        }
+    ],
     "extra": {
         "laravel": {
             "providers": [
@@ -37,5 +49,11 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require-dev": {
+        "phpunit/phpunit": "^8"
+    },
+    "scripts": {
+        "test": "phpunit --colors=always tests"
+    }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -504,6 +504,11 @@ Feel free to suggest changes, ask for new features or fix bugs yourself. We're s
 
 Thanks!
 
+### Unit tests
+
+To ensure your change keeps working add an unit test. The current set of tests is limited, but every unit test added wil improve the quality of the package.
+
+Run PHPUnit by calling `composer test`.
 
 ## Made with ❤️ for open source
 At [Whitecube](https://www.whitecube.be) we use a lot of open source software as part of our daily work.

--- a/tests/Unit/Layouts/CollectionTest.php
+++ b/tests/Unit/Layouts/CollectionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Unit\Layouts;
+
+use PHPUnit\Framework\TestCase;
+use Whitecube\NovaFlexibleContent\Layouts\Collection;
+use Whitecube\NovaFlexibleContent\Layouts\Layout;
+
+class CollectionTest extends TestCase {
+
+    public function testFind(): void {
+        $collection = new Collection([new Layout('Foo', 'bar')]);
+
+        $this->assertNotNull($collection->find('bar'));
+        $this->assertNull($collection->find('a-name'));
+    }
+
+}


### PR DESCRIPTION
At GRRR we use this package more and more. @harmenjanssen who created some PR's is a colleague of mine. To increase the quality of this package we would like to be able to write unit tests. Hopefully you're willing to accept this rather big change.

I've added PHPUnit and a workflow file to run the unit tests every time a push is made. The workflow requires a Nova license. Two secrets (`NOVA_USERNAME` and `NOVA_PASSWORD`) have to added to the repo.