### PR TITLE
Allow user to pass in pre-initialized resolver object to resolver method

### DIFF
--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -144,7 +144,7 @@ class Flexible extends Field
      */
     public function resolver($resolver)
     {
-        if(!($resolver instanceof ResolverInterface)) {
+        if (is_string($resolver) && is_a($resolver, ResolverInterface::class, true)) {
             $resolver = new $resolver();
         }
 

--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -139,12 +139,14 @@ class Flexible extends Field
     /**
      * Set the field's resolver
      *
-     * @param string $classname
+     * @param mixed $resolver
      * @return $this
      */
-    public function resolver($classname)
+    public function resolver($resolver)
     {
-        $resolver = new $classname();
+        if(!($resolver instanceof ResolverInterface)) {
+            $resolver = new $resolver();
+        }
 
         if(!($resolver instanceof ResolverInterface)) {
             throw new \Exception('Resolver Class "' . get_class($resolver) . '" does not implement ResolverInterface.');


### PR DESCRIPTION
Allows user to pass in a pre-initialized resolver object. My case is as follows: I have an one-to-many relationship and I am using Flexible to create a new child resource. The layout fields are dynamic and they depend on attributes of the parent resource. The use of the custom resolver is to get/set data from/to a related entity table (related to parent also). The `$resource` argument on `public function get($resource, $attribute, $layouts)` method is an empty (child) resource when clicking the create button, so I do not have access to the parent entity. It may be possible to use the current `request()` to load the parent entity from the route params but with this change I just passing the parent entity to the resolver as constructor argument (and any other data I may need). Hope that helps other similar cases too.