### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.2.5",
         "laravel/nova": "^3.2",
-        "laravel/framework": "^7.0"
+        "spatie/laravel-medialibrary": "^9.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
in `Whitecube\NovaFlexibleContent\Concerns\HasMediaLibrary` this package interacts with parts of `spatie/laravel-medialibrary`. Even if this trait is optional, the dependencies should be installed nevertheless.