### PR TITLE
Convert empty string to null (like Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull does)

### DIFF
--- a/src/Http/FlexibleAttribute.php
+++ b/src/Http/FlexibleAttribute.php
@@ -198,6 +198,8 @@ class FlexibleAttribute
      */
     public function setDataIn(&$attributes, $value)
     {
+        $value = is_string($value) && $value === '' ? null : $value;
+        
         if(!$this->isAggregate()) {
             $attributes[$this->name] = $value;
             return $attributes;


### PR DESCRIPTION
Convert empty string to null (like Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull does)

Fix https://github.com/whitecube/nova-flexible-content/issues/282