### PR TITLE
Fix Flexible cast inside Tinker

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -33,7 +33,7 @@ trait HasFlexible {
      */
     public function cast($value, $layoutMapping = [])
     {
-        if(app()->getProvider(NovaServiceProvider::class) && !app()->environment('testing')) {
+        if(app()->getProvider(NovaServiceProvider::class) && !app()->runningInConsole() && !app()->environment('testing')) {
             return $value;
         }
 


### PR DESCRIPTION
The Flexible cast doesn't work inside Tinker, because the NovaServiceProvider is loaded. This is a suggested fix for this issue.