### PR TITLE
Calculate the dropdown height dynamically

### DIFF
--- a/resources/js/components/OriginalDropMenu.vue
+++ b/resources/js/components/OriginalDropMenu.vue
@@ -1,7 +1,8 @@
 <template>
     <div class="z-20 relative" v-if="layouts">
         <div class="relative" v-if="layouts.length > 1">
-            <div v-if="isLayoutsDropdownOpen"
+            <div v-if="isLayoutsDropdownOpen" 
+                 ref="dropdown"
                  class="absolute rounded-lg shadow-lg max-w-full mb-3 pin-b max-h-search overflow-y-auto border border-40"
             >
                 <div>
@@ -53,6 +54,18 @@
                 }
 
                 this.isLayoutsDropdownOpen = !this.isLayoutsDropdownOpen;
+                
+                this.$nextTick(() => {
+                    if (this.isLayoutsDropdownOpen) {
+                        const { top, height } = this.$refs.dropdown.getBoundingClientRect();
+                        // If element's y position is outside the screen, 
+                        // update the element's height so it fits the window.
+                        if (top < 0) {
+                            // Note that `top` is negative, so this addition is actually subtraction!
+                            this.$refs.dropdown.style.height = `${height + top}px`;
+                        }
+                    }
+                });
             },
 
             /**


### PR DESCRIPTION
To make sure it doesn't creep out of the window at the top, we
recalculate its height client-side based on its y position.
This ensures the dropdown is only ever as high as the top of the screen.
Scrollbars (thanks to overflow-y: auto) will take care of the rest.

This fixes cases where the button is high on the screen, causing the
first options in the dropdown to be unselectable.

Let me know what you think of this solution, and what should be changed to make this mergable. 
It would help our client who currently has to add some random layouts to make the page tall enough to show the first options! 😱 

Thanks in advance.