### PR TITLE
Remove hardcoded environment check

### DIFF
--- a/src/Concerns/HasFlexible.php
+++ b/src/Concerns/HasFlexible.php
@@ -33,7 +33,7 @@ trait HasFlexible {
      */
     public function cast($value, $layoutMapping = [])
     {
-        if(app()->getProvider(NovaServiceProvider::class) && !app()->runningInConsole() && !app()->environment('testing')) {
+        if(app()->getProvider(NovaServiceProvider::class) && !app()->runningInConsole()) {
             return $value;
         }
 


### PR DESCRIPTION
`app()->runningInConsole()` solves the problem with unit tests, so we don't need this hardcoded environment check any longer. 
Additionally, if we want to use `testing` environment instead of `local` for some reason ( to check something while developing ), this env check will cause errors on nova pages with flexible fields.