### PR TITLE
Laravel 9 Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=7.2.5",
         "laravel/nova": "^3.2",
-        "laravel/framework": "^7.0|^8.0"
+        "laravel/framework": "^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
PR allows people to upgrade to Laravel 9.

I've gone through the package and tested several functions. Additionally, we have a few sites running Laravel 9 and flexible content with no issues. Everything seems to work for Laravel 9. Nothing in the upgrade guide stood out to me for being a breaking change. Laravel 8 to 9 isn't a huge shift.