### PR TITLE
Fix dropdown z-index

### DIFF
--- a/resources/js/components/OriginalDropMenu.vue
+++ b/resources/js/components/OriginalDropMenu.vue
@@ -2,7 +2,7 @@
     <div class="relative" v-if="layouts">
         <div class="z-20" v-if="layouts.length > 1">
             <div v-if="isLayoutsDropdownOpen"
-                 class="absolute rounded-lg shadow-lg max-w-full top-full mt-3 pin-b max-h-search overflow-y-auto border border-gray-100 dark:border-gray-700 "
+                 class="z-20 absolute rounded-lg shadow-lg max-w-full top-full mt-3 pin-b max-h-search overflow-y-auto border border-gray-100 dark:border-gray-700 "
             >
                 <div>
                     <ul class="list-reset">


### PR DESCRIPTION
If there is flexible content inside flexible content, the z-index is wrong the later button is shown over the inner scope button dropdown.