### PR TITLE
Add use statement for Layout class

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Ebess\AdvancedNovaMediaLibrary\Fields\Media;
 use Whitecube\NovaFlexibleContent\Http\ScopedRequest;
+use Whitecube\NovaFlexibleContent\Layouts\Layout;
 
 trait HasMediaLibrary {
 


### PR DESCRIPTION
Required by `while ($model instanceof Layout)`. 

Fixes issue where sublayouts cannot be resolved to the Media model as described in https://github.com/whitecube/nova-flexible-content/pull/358.