### PR TITLE
feat(ScopedRequest): model scope on request

### DIFF
--- a/src/Http/ScopedRequest.php
+++ b/src/Http/ScopedRequest.php
@@ -7,6 +7,8 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 class ScopedRequest extends NovaRequest
 {
 
+    public $group;
+
     /**
      * Create a copy of the given request, only containing the group's input
      *
@@ -29,6 +31,9 @@ class ScopedRequest extends NovaRequest
      */
     public function scopeInto($group, $attributes)
     {
+
+        $this->group = $group;
+
         [$input, $files] = $this->getScopeState($group, $attributes);
         
         $input['_method'] = $this->input('_method');


### PR DESCRIPTION
This includes the group key as a property on the ScopedRequest class.

Useful if you want to do anything with the scoped request (specifically in any of the `get{specificity}Rules` methods) within any fields that may be in the layout. Without this context there is nothing to inform which group you are currently working with (and therefore no way to create and return a `FlexibleAttribute`)