### PR TITLE
add exits and wasrecentlycreated

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -22,6 +22,21 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
     use HidesAttributes;
     use HasFlexible;
 
+
+    /**
+     * Define that Layout is a model, when in fact it is not.
+     *
+     * @var bool
+     */
+    protected $exists = false;
+
+    /**
+     * Define that Layout is a model, when in fact it is not.
+     *
+     * @var bool
+     */
+    protected $wasRecentlyCreated = false;
+
     /**
      * The layout's name
      *


### PR DESCRIPTION
Please add this to fix the "Undefined property: Whitecube\NovaFlexibleContent\Layouts\Layout::$exists" error for nova 3 users.