### PR TITLE
feat: Update Error Bag on response exception

### DIFF
--- a/src/Http/TransformsFlexibleErrors.php
+++ b/src/Http/TransformsFlexibleErrors.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
 use Whitecube\NovaFlexibleContent\Flexible;
+use Illuminate\Contracts\Support\MessageBag;
 
 trait TransformsFlexibleErrors
 {

--- a/src/Http/TransformsFlexibleErrors.php
+++ b/src/Http/TransformsFlexibleErrors.php
@@ -30,11 +30,15 @@ trait TransformsFlexibleErrors
      */
     protected function transformFlexibleErrors(Response $response)
     {
-        $response->setData(
-            $this->updateResponseErrors($response->original)
-        );
+        $updatedResponseErrors = $this->updateResponseErrors($response->original);
 
-        return $response;
+        $errorBag = $response->exception?->validator?->errors();
+        if ($errorBag instanceof MessageBag) {
+            $replaceMessages = function (array $messages) { $this->messages = $messages; };
+            $replaceMessages->call($errorBag, $updatedResponseErrors['errors']);
+        }
+
+        return $response->setData($updatedResponseErrors);
     }
 
     /**


### PR DESCRIPTION
- Updates the Error Bag on the exception attached to the response, in addition to the response data
- Allows any other middleware executing after TransformsFlexibleErrors that interacts with the Exception/Validator directly to use the correct keys