### PR TITLE
Fix array decoding polymorphic relationships

### DIFF
--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -405,7 +405,9 @@ class Flexible extends Field
         }
 
         if (! is_array($value)) {
-            throw new \Exception('Unable to parse incoming Flexible content, data should be an array.');
+            if(!$value = @json_decode($value, true)) {
+                throw new \Exception('Unable to parse incoming Flexible content, data should be an array.');
+            }
         }
 
         return $value;


### PR DESCRIPTION
In polymorphic relationships the nested content is not decoded/casted to an array. 

This fix will test again if the nested json object can be decoded to an array. 

See: https://github.com/whitecube/nova-flexible-content/issues/435

![Screenshot 2023-02-16 at 10 04 53](https://user-images.githubusercontent.com/3843532/219321809-d2ad7ce0-7d5e-41b4-b35d-2bd6379986ae.png)
