### PR TITLE
Update Psalm and update Psalm check on CI (reuse Psalm's cache)

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -11,35 +11,42 @@ on:
 jobs:
   psalm:
     name: Psalm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 6
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-
-      # mtime needs to be restored for Psalm cache to work correctly
-      - name: Restore mtimes
-        uses: chetan/git-restore-mtime-action@v1
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           coverage: none
 
-      - name: Install composer dependencies
-        run: |
-          composer config --ansi -- http-basic.nova.laravel.com ${{ secrets.NOVA_USERNAME }} ${{ secrets.NOVA_LICENSE_KEY }}
-          composer install --no-interaction --no-progress --no-scripts
+      - uses: actions/checkout@v3
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       # the way cache keys are set up will always cause a cache miss
       # but will restore the cache generated during the previous run based on partial match
       - name: Retrieve Psalm’s cache
         uses: actions/cache@v3
         with:
-          path: ./cache/psalm
+          path: ./.cache/psalm
           key: ${{ runner.os }}-psalm-cache-${{ hashFiles('psalm.xml', 'psalm-baseline.xml', './composer.json') }}
 
+      # mtime needs to be restored for Psalm cache to work correctly
+      - name: Restore mtimes
+        uses: chetan/git-restore-mtime-action@v1
+
+      - name: Install composer dependencies
+        run: |
+          composer config --ansi -- http-basic.nova.laravel.com ${{ secrets.NOVA_USERNAME }} ${{ secrets.NOVA_LICENSE_KEY }}
+          composer update --prefer-dist --no-interaction --no-suggest --ansi
+
       - name: Run Psalm
-        run: ./vendor/bin/psalm --find-unused-psalm-suppress --output-format=github
+        run: ./vendor/bin/psalm --output-format=github

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ phpunit.xml
 Thumbs.db
 yarn-error.log
 webpack.mix.js
+
+# Used by Psalm and potentially by other tools
+/.cache

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
     "require-dev": {
         "laravel/pint": "^1.2",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-laravel": "^2.0"
+        "psalm/plugin-laravel": "^2.0",
+        "vimeo/psalm": "^5.13"
     },
     "scripts": {
         "psalm": "psalm --find-unused-psalm-suppress --output-format=phpstorm",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
   <file src="src/FileAdder/FileAdder.php">
     <UndefinedClass>
       <code>OriginalFileAdder</code>
@@ -14,6 +14,14 @@
     <UndefinedClass>
       <code>$model</code>
       <code>\Whitecube\NovaPage\Pages\Template</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass>
+      <code>parent::getRules($request)</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Http/TransformsFlexibleErrors.php">
+    <UndefinedClass>
+      <code>JsonResponse</code>
     </UndefinedClass>
   </file>
   <file src="src/Layouts/Collection.php">

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     findUnusedCode="false"
     findUnusedBaselineEntry="false"
     errorBaseline="psalm-baseline.xml"
+    cacheDirectory=".cache/psalm"
 >
     <projectFiles>
         <directory name="src"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+    findUnusedBaselineEntry="false"
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>

--- a/src/Stubs/Cast.stub
+++ b/src/Stubs/Cast.stub
@@ -4,8 +4,12 @@ namespace App\Casts;
 
 use Whitecube\NovaFlexibleContent\Value\FlexibleCast;
 
+/** @extends \Whitecube\NovaFlexibleContent\Value\FlexibleCast */
 class :classname extends FlexibleCast
 {
+    /**
+     * @var array<string, class-string<\Whitecube\NovaFlexibleContent\Layouts\LayoutInterface>>
+     */
     protected $layouts = [
         // Define your layout mappings
     ];

--- a/src/Value/FlexibleCast.php
+++ b/src/Value/FlexibleCast.php
@@ -5,12 +5,17 @@ namespace Whitecube\NovaFlexibleContent\Value;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Whitecube\NovaFlexibleContent\Concerns\HasFlexible;
 
+/**
+ * @template TGet of string
+ * @template TSet of \Whitecube\NovaFlexibleContent\Layouts\Layout
+ * @implements \Illuminate\Contracts\Database\Eloquent\CastsAttributes<TGet, TSet>
+ */
 class FlexibleCast implements CastsAttributes
 {
     use HasFlexible;
 
     /**
-     * @var array
+     * @var array<string, class-string<\Whitecube\NovaFlexibleContent\Layouts\LayoutInterface>>
      */
     protected $layouts = [];
 


### PR DESCRIPTION
This PR includes:
 - new minimal Psalm version (no new PHP or other dependency restrictions)
 - Fix new `@template` syntax issues (detected by a newer Psalm version)
 - Reuse Psalm's cache on CI
 - Unify psalm.yml with ci.yml

After these changes Psalm on CI should be green (however now sure about Nova installation as it requires a Nova license key):
```
*****************************************************
Your license is not allowed to download this release!
*****************************************************
    Failed to download laravel/nova from dist: The 'https://nova.laravel.com/dist/laravel/nova/laravel-nova-b7537f667ef4ee6a1c9581995d438a6fe214625b-zip-ae794f.zip' URL could not be accessed (HTTP 403): HTTP/2 403 
    Now trying to download from source
  - Syncing laravel/nova (4.25.1) into cache

Error: Failed to execute git clone --mirror -- 'git@github.com:laravel/nova.git' '/home/runner/.cache/composer/vcs/git-github.com-laravel-nova.git/'

Cloning into bare repository '/home/runner/.cache/composer/vcs/git-github.com-laravel-nova.git'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```


But I used same commands for Psalm that you used for PHPUnit, probably it will help