### PR TITLE
Fix PHPDoc for Layout class and related code, fix return types

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,29 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.6.0@e784128902dfe01d489c4123d69918a9f3c1eac5">
+<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
   <file src="src/FileAdder/FileAdder.php">
     <UndefinedClass>
-      <code>OriginalFileAdder</code>
+      <code><![CDATA[OriginalFileAdder]]></code>
     </UndefinedClass>
   </file>
   <file src="src/FileAdder/FileAdderFactory.php">
     <UndefinedClass>
-      <code>OriginalFileAdderFactory</code>
+      <code><![CDATA[OriginalFileAdderFactory]]></code>
     </UndefinedClass>
   </file>
   <file src="src/Flexible.php">
+    <MethodSignatureMismatch>
+      <code><![CDATA[Flexible]]></code>
+    </MethodSignatureMismatch>
     <UndefinedClass>
-      <code>$model</code>
-      <code>\Whitecube\NovaPage\Pages\Template</code>
+      <code><![CDATA[$model]]></code>
+      <code><![CDATA[\Whitecube\NovaPage\Pages\Template]]></code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Http/TransformsFlexibleErrors.php">
+    <UndefinedClass>
+      <code><![CDATA[JsonResponse]]></code>
     </UndefinedClass>
   </file>
   <file src="src/Layouts/Collection.php">
     <UnimplementedInterfaceMethod>
-      <code>Collection</code>
+      <code><![CDATA[Collection]]></code>
     </UnimplementedInterfaceMethod>
   </file>
   <file src="src/Layouts/Layout.php">
     <UndefinedTrait>
-      <code>HasAttributes</code>
+      <code><![CDATA[HasAttributes]]></code>
     </UndefinedTrait>
   </file>
 </files>

--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -138,11 +138,11 @@ trait HasMediaLibrary
      *
      * @param  Flexible  $flexible
      * @param  Layout  $layout
-     * @return mixed
+     * @return void
      */
     protected function removeCallback(Flexible $flexible, $layout)
     {
-        if ($this->shouldDeletePreservingMedia()) {
+        if ($this instanceof \Spatie\MediaLibrary\HasMedia && $this->shouldDeletePreservingMedia()) {
             return;
         }
 

--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -14,6 +14,9 @@ use Whitecube\NovaFlexibleContent\Layouts\Preset;
 use Whitecube\NovaFlexibleContent\Value\Resolver;
 use Whitecube\NovaFlexibleContent\Value\ResolverInterface;
 
+/**
+ * @phpstan-import-type TFieldValidationRules from \Laravel\Nova\Fields\Field
+ */
 class Flexible extends Field
 {
     use SupportsDependentFields;
@@ -374,7 +377,7 @@ class Flexible extends Field
     /**
      * Fire's the remove callbacks on the layouts
      *
-     * @param  \Illuminate\Support\Collection<\Whitecube\NovaFlexibleContent\Layouts\Layout>  $new_groups This should be (all) the new groups to bne compared against to find the removed groups
+     * @param  \Illuminate\Support\Collection<array-key, \Whitecube\NovaFlexibleContent\Layouts\Layout>  $new_groups This should be (all) the new groups to bne compared against to find the removed groups
      * @return void
      */
     protected function fireRemoveCallbacks(Collection $new_groups)
@@ -493,7 +496,8 @@ class Flexible extends Field
      * Get the validation rules for this field & its contained fields.
      *
      * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
-     * @return array
+     * @return array<array-key, array<int, mixed>>
+     * @phpstan-return array<string, array<int, TFieldValidationRules>>
      */
     public function getRules(NovaRequest $request)
     {

--- a/src/Flexible.php
+++ b/src/Flexible.php
@@ -374,14 +374,16 @@ class Flexible extends Field
     /**
      * Fire's the remove callbacks on the layouts
      *
-     * @param  Collection  $new_groups This should be (all) the new groups to bne compared against to find the removed groups
+     * @param  \Illuminate\Support\Collection<\Whitecube\NovaFlexibleContent\Layouts\Layout>  $new_groups This should be (all) the new groups to bne compared against to find the removed groups
+     * @return void
      */
     protected function fireRemoveCallbacks(Collection $new_groups)
     {
         $new_group_keys = $new_groups->map(function ($item) {
             return $item->inUseKey();
         });
-        $removed_groups = $this->groups->filter(function ($item) use ($new_group_keys) {
+
+        $this->groups->filter(function ($item) use ($new_group_keys) {
             return ! $new_group_keys->contains($item->inUseKey());
         })->each(function ($group) {
             if (method_exists($group, 'fireRemoveCallback')) {

--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -82,12 +82,14 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
 
     /**
      * The callback to be called when this layout is removed
+     * @var callable(\Whitecube\NovaFlexibleContent\Flexible, \Whitecube\NovaFlexibleContent\Layouts\Layout): void
      */
     protected $removeCallbackMethod;
 
     /**
      * The maximum amount of this layout type that can be added
      * Can be set in custom layouts
+     * @var int<0, max>|null
      */
     protected $limit;
 
@@ -129,13 +131,12 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
     /**
      * Create a new base Layout instance
      *
-     * @param  string  $title
-     * @param  string  $name
-     * @param  array  $fields
-     * @param  string  $key
+     * @param  string|null  $title
+     * @param  string|null  $name
+     * @param  list<\Laravel\Nova\Fields\Field>|\Laravel\Nova\Fields\FieldCollection|null  $fields
+     * @param  string|null  $key
      * @param  array  $attributes
-     * @param  callable|null  $removeCallbackMethod
-     * @param  int|null  $limit
+     * @param  (callable(\Whitecube\NovaFlexibleContent\Flexible, \Whitecube\NovaFlexibleContent\Layouts\Layout): void)|null  $removeCallbackMethod
      * @return void
      */
     public function __construct($title = null, $name = null, $fields = null, $key = null, $attributes = [], callable $removeCallbackMethod = null)
@@ -274,12 +275,12 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
             $fields,
             $key,
             $attributes,
-            $this->removeCallbackMethod,
-            $this->limit
+            $this->removeCallbackMethod
         );
         if (! is_null($this->model)) {
             $clone->setModel($this->model);
         }
+        $clone->limit = $this->limit;
 
         return $clone;
     }
@@ -450,23 +451,23 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
      * The method to call when this layout is removed
      *
      * @param  Flexible  $flexible
-     * @return mixed
+     * @return void
      */
     public function fireRemoveCallback(Flexible $flexible)
     {
         if (is_callable($this->removeCallbackMethod)) {
-            return $this->removeCallbackMethod($flexible, $this);
+            $this->removeCallbackMethod($flexible, $this);
         }
 
-        return $this->removeCallback($flexible, $this);
+        $this->removeCallback($flexible, $this);
     }
 
     /**
      * The default behaviour when removed
      *
      * @param  Flexible  $flexible
-     * @param  \Whitecube\NovaFlexibleContent\Layout  $layout
-     * @return mixed
+     * @param  \Whitecube\NovaFlexibleContent\Layouts\Layout  $layout
+     * @return void
      */
     protected function removeCallback(Flexible $flexible, $layout)
     {

--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -393,7 +393,7 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
     /**
      * Force Fill the layout with an array of attributes.
      *
-     * @param  array  $attributes
+     * @param  array<string, mixed>  $attributes
      * @return $this
      */
     public function forceFill(array $attributes)

--- a/src/Value/FlexibleCast.php
+++ b/src/Value/FlexibleCast.php
@@ -5,6 +5,7 @@ namespace Whitecube\NovaFlexibleContent\Value;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Whitecube\NovaFlexibleContent\Concerns\HasFlexible;
 
+/** @implements \Illuminate\Contracts\Database\Eloquent\CastsAttributes<\Whitecube\NovaFlexibleContent\Layouts\Collection<array-key, \Whitecube\NovaFlexibleContent\Layouts\Layout>, mixed> */
 class FlexibleCast implements CastsAttributes
 {
     use HasFlexible;
@@ -20,7 +21,7 @@ class FlexibleCast implements CastsAttributes
     protected $model;
 
     /**
-     * @return \Whitecube\NovaFlexibleContent\Layouts\Collection|array<\Whitecube\NovaFlexibleContent\Layouts\Layout>
+     * @return \Whitecube\NovaFlexibleContent\Layouts\Collection<array-key, \Whitecube\NovaFlexibleContent\Layouts\Layout>
      */
     public function get($model, string $key, $value, array $attributes)
     {


### PR DESCRIPTION
There is only one arguable change: `fireRemoveCallback()` method return type (it's declared as `mixed`) is unused in the package. I propose to remove it.


I also found a weird situation with `Layout::$limit`, not sure where it should be set, but I fixed PHPDoc for the constructor (it contained $limit that was removed by https://github.com/whitecube/nova-flexible-content/commit/ca0b6e53f834948a4f7f79aa714d8ee721e3fe3e), also one Layout object initiation was using this removed parameter (I removed it) and fixed `duplicateAndHydrate` method where I think the value of this property should be copied/replicated.