### PR TITLE
Changed rtrim to str_replace inside "determineDiskName" method

### DIFF
--- a/src/FileAdder/FileAdder.php
+++ b/src/FileAdder/FileAdder.php
@@ -34,7 +34,7 @@ class FileAdder extends OriginalFileAdder
     public function determineDiskName(string $diskName, string $collectionName): string
     {
         if ($this->media_collection_suffix) {
-            $collectionName = rtrim($collectionName, $this->media_collection_suffix);
+            $collectionName = str_replace($this->media_collection_suffix, '', $collectionName);
         }
 
         return parent::determineDiskName($diskName, $collectionName);


### PR DESCRIPTION
There was an issue with **rtrim** which removed also the last character from the `$collectionName`. 

### Example

I have multiple different disks defined inside `config/filesystems.php`.
I have a custom layout created `App\Nova\Flexible\Layouts\GalleryLayout` with the `HasMediaLibrary` trait. The name of the attribute there is `articleImage` which represents the name of the collection inside the **determineDiskName** --> `whitecube/nova-flexible-content/src/FileAdder/FileAdder.php:34`.

So the `$collectionName` together with suffix is something like: `articleImage_cTWnzJ0PsPJXzxWJ`.

After the **rtrim** result I've got: `articleImag` This caused that the **determineDiskName** method always returned the `public` disk, because such collection was not found.

The `str_replace` fixes this issue.