### PR TITLE
Add missing preventsAccessingMissingAttributes method

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -149,6 +149,16 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
     }
 
     /**
+     * Determine if accessing missing attributes is disabled.
+     *
+     * @return bool
+     */
+    public static function preventsAccessingMissingAttributes()
+    {
+        return false;
+    }
+
+    /**
      * Set the parent model instance
      *
      * @param  Model  $model


### PR DESCRIPTION
Closes #495. 

Recent run-time error introduced with Laravel v10.40. 

I don't think it makes sense to use this feature with flexible content, so I gave it a hard-coded `false` value. It serves solely as a placeholder.