### PR TITLE
Rename getMediaModel to getUnderlyingMediaModel function

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -23,7 +23,7 @@ trait HasMediaLibrary
      *
      * @return \Spatie\MediaLibrary\HasMedia
      */
-    public function getMediaModel(): HasMedia
+    protected function getUnderlyingMediaModel(): HasMedia
     {
         $model = Flexible::getOriginModel() ?? $this->model;
 
@@ -47,7 +47,7 @@ trait HasMediaLibrary
     public function addMedia($file): \Spatie\MediaLibrary\MediaCollections\FileAdder
     {
         return app(FileAdderFactory::class)
-            ->create($this->getMediaModel(), $file, $this->getSuffix())
+            ->create($this->getUnderlyingMediaModel(), $file, $this->getSuffix())
             ->preservingOriginal();
     }
 
@@ -85,7 +85,7 @@ trait HasMediaLibrary
         }
 
         return app(FileAdderFactory::class)
-            ->create($this->getMediaModel(), $temporaryFile, $this->getSuffix())
+            ->create($this->getUnderlyingMediaModel(), $temporaryFile, $this->getSuffix())
             ->usingName(pathinfo($filename, PATHINFO_FILENAME))
             ->usingFileName($filename);
     }
@@ -100,7 +100,7 @@ trait HasMediaLibrary
     public function getMedia(string $collectionName = 'default', $filters = []): Collection
     {
         return app(MediaRepository::class)
-            ->getCollection($this->getMediaModel(), $collectionName.$this->getSuffix(), $filters);
+            ->getCollection($this->getUnderlyingMediaModel(), $collectionName.$this->getSuffix(), $filters);
     }
 
     /**
@@ -123,7 +123,7 @@ trait HasMediaLibrary
     {
         $this->fields->each(function ($field) use ($attributes) {
             if (is_a($field, Media::class)) {
-                $field->resolveForDisplay($this->getMediaModel(), $field->attribute.$this->getSuffix());
+                $field->resolveForDisplay($this->getUnderlyingMediaModel(), $field->attribute.$this->getSuffix());
             } else {
                 $field->resolveForDisplay($attributes);
             }


### PR DESCRIPTION
As referenced in issue #505, this should fix the problems.

The default getMediaModel function is declared in the trait InteractsWithMedia, from the spatie package