### PR TITLE
Fix incomplete getUnderlyingMediaModel fix

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -23,12 +23,12 @@ trait HasMediaLibrary
      *
      * @return \Spatie\MediaLibrary\HasMedia
      */
-    protected function getUnderlyingMediaModel(): HasMedia
+    public function getUnderlyingMediaModel(): HasMedia
     {
         $model = Flexible::getOriginModel() ?? $this->model;
 
         while ($model instanceof Layout) {
-            $model = $model->getMediaModel();
+            $model = $model->getUnderlyingMediaModel();
         }
 
         if (is_null($model) || ! ($model instanceof HasMedia)) {


### PR DESCRIPTION
PR [#509](https://github.com/whitecube/nova-flexible-content/pull/509) attempted to rectify the retrieval of the origin model, but the fix is incomplete. For some reason, the while loop was skipped but this is absolutely necessary for the proper functioning of nested layouts.