### PR TITLE
Fix: Ensure duplicateAndHydrate works with Fields using static closures

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -310,7 +310,14 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
             if (! is_a($field->$callable ?? null, \Closure::class)) {
                 continue;
             }
-            $field->$callable = $field->$callable->bindTo($field);
+
+            try {
+                $field->$callable = $field->$callable->bindTo($field);
+            } catch (\Throwable $th) {
+                // Binding an instance to a static closure will fail. Assuming
+                // that's the cause of the error here, we leave the original
+                // closure as-is.
+            }
         }
 
         return $field;

--- a/tests/Unit/Layouts/LayoutTest.php
+++ b/tests/Unit/Layouts/LayoutTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Layouts;
+
+use PHPUnit\Framework\TestCase;
+use Laravel\Nova\Fields\DateTime;
+use Laravel\Nova\Fields\Text;
+use Whitecube\NovaFlexibleContent\Layouts\Layout;
+
+class LayoutTest extends TestCase
+{
+    public function testDuplicateAndHydrate(): void
+    {
+        $layout = new Layout('Test Layout', 'test', [
+            DateTime::make('Created At'),
+            Text::make('Name', 'name', static function($resource, $attribute) {
+                return 'static-name';
+            }),
+        ]);
+
+        // Should not throw any exceptions
+        $duplicate = $layout->duplicateAndHydrate('keylikegenerated', [
+            'created_at' => '2023-01-01 00:00:00',
+            'name' => 'Test'
+        ]);
+
+        $this->assertInstanceOf(Layout::class, $duplicate);
+        $this->assertEquals('keylikegenerated', $duplicate->key());
+        $this->assertEquals('Test Layout', $duplicate->title());
+        $this->assertEquals('test', $duplicate->name());
+
+        // The text field should resolve the value
+        $textField = $duplicate->fields()[1];
+        $textField->resolve(null);
+        $this->assertEquals('static-name', $textField->value);
+    }
+}


### PR DESCRIPTION
Nova's DateTime field (at least the one in Nova v5) uses a static anonymous function to define how to resolve the data to a string. This causes problems in the `cloneField` (and the dependent `duplicateAndHydrate`) method in your code, which binds a few of the field callbacks back to the newly cloned field instance. The specific error is:

```
Cannot bind an instance to a static closure
```

I initially implemented a fix using ReflectionFunction to detect if a function is static, but settled for a try-catch just in case reflection causes some sort of performance issue at low numbers.