### PR TITLE
Update Layout.php

### DIFF
--- a/src/Layouts/Layout.php
+++ b/src/Layouts/Layout.php
@@ -310,7 +310,13 @@ class Layout implements LayoutInterface, JsonSerializable, ArrayAccess, Arrayabl
             if (! is_a($field->$callable ?? null, \Closure::class)) {
                 continue;
             }
-            $field->$callable = $field->$callable->bindTo($field);
+             try {
+                $field->$callable = $field->$callable->bindTo($field);
+            } catch (\Throwable $th) {
+                // Binding an instance to a static closure will fail. Assuming
+                // that's the cause of the error here, we leave the original
+                // closure as-is.
+            }
         }
 
         return $field;


### PR DESCRIPTION
Nova's DateTime field (at least the one in Nova v5) uses a static anonymous function to define how to resolve the data to a string. This causes problems in the cloneField (and the dependent duplicateAndHydrate) method in your code, which binds a few of the field callbacks back to the newly cloned field instance. The specific error is:

Cannot bind an instance to a static closure
I initially implemented a fix using ReflectionFunction to detect if a function is static, but settled for a try-catch just in case reflection causes some sort of performance issue at low numbers.