### PR TITLE
Fixed typo for getLayoutMapping references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ class MyFlexibleCast extends FlexibleCast
 }
 ```
 
-If you need more control, you can [override the `getLayoutMappings` method](https://whitecube.github.io/nova-flexible-content/#/?id=having-more-control-over-the-layout-mappings) instead.
+If you need more control, you can [override the `getLayoutMapping` method](https://whitecube.github.io/nova-flexible-content/#/?id=having-more-control-over-the-layout-mappings) instead.
 
 #### The Layouts Collection
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -173,14 +173,14 @@ class MyFlexibleCast extends FlexibleCast
 
 #### Having more control over the layout mappings
 
-If you need to do complex things with your mappings instead of having a static array as shown above, you can override the `getLayoutMappings` method on your cast.
+If you need to do complex things with your mappings instead of having a static array as shown above, you can override the `getLayoutMapping` method on your cast.
 
 ```php
 namespace App\Casts;
 
 class MyFlexibleCast extends FlexibleCast
 {
-    protected function getLayoutMappings()
+    protected function getLayoutMapping()
     {
         $mappings = [];
         


### PR DESCRIPTION
I have updated the docs which reference `getLayoutMappings()` to match the correct method in `FlexibleCast.php`, which is `getLayoutMapping()`.

Not a huge deal, as it's very simple to dig into `FlexibleCast.php` and see that the correct method name is `getLayoutMapping`, but thought I'd update the docs for everyone's future reference.

Cheers.