### PR TITLE
fix: Add support for dependsOn inside flexible content fields

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -10,6 +10,7 @@ use Whitecube\NovaFlexibleContent\Commands\CreateLayout;
 use Whitecube\NovaFlexibleContent\Commands\CreatePreset;
 use Whitecube\NovaFlexibleContent\Commands\CreateResolver;
 use Whitecube\NovaFlexibleContent\Http\Middleware\InterceptFlexibleAttributes;
+use Whitecube\NovaFlexibleContent\Http\Middleware\InterceptFlexibleDependsOnAttributes;
 
 class FieldServiceProvider extends ServiceProvider
 {
@@ -57,6 +58,7 @@ class FieldServiceProvider extends ServiceProvider
 
         if ($router->hasMiddlewareGroup('nova')) {
             $router->pushMiddlewareToGroup('nova', InterceptFlexibleAttributes::class);
+            $router->pushMiddlewareToGroup('nova', InterceptFlexibleDependsOnAttributes::class);
 
             return;
         }
@@ -64,7 +66,7 @@ class FieldServiceProvider extends ServiceProvider
         if (! $this->app->configurationIsCached()) {
             config()->set('nova.middleware', array_merge(
                 config('nova.middleware', []),
-                [InterceptFlexibleAttributes::class]
+                [InterceptFlexibleAttributes::class, InterceptFlexibleDependsOnAttributes::class]
             ));
         }
     }

--- a/src/Http/Middleware/InterceptFlexibleDependsOnAttributes.php
+++ b/src/Http/Middleware/InterceptFlexibleDependsOnAttributes.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Whitecube\NovaFlexibleContent\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Whitecube\NovaFlexibleContent\Http\FlexibleAttribute;
+
+class InterceptFlexibleDependsOnAttributes
+{
+    /**
+     * Handle the given request and get the response.
+     *
+     * This middleware transforms flexible content field names in dependsOn requests
+     * by stripping the group key prefix so that the dependsOn callbacks receive
+     * the original field names they expect.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $this->shouldTransformRequest($request)) {
+            return $next($request);
+        }
+
+        $this->transformFlexibleFieldNames($request);
+
+        return $next($request);
+    }
+
+    /**
+     * Determine if the request should be transformed.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function shouldTransformRequest(Request $request): bool
+    {
+        // Only intercept Nova's dependent field requests
+        if (! $this->isDependentFieldRequest($request)) {
+            return false;
+        }
+
+        // Only transform if the request contains flexible content field names
+        return $this->hasFlexibleFieldNames($request);
+    }
+
+    /**
+     * Check if this is a Nova dependent field request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function isDependentFieldRequest(Request $request): bool
+    {
+        $path = $request->path();
+
+        // Match Nova API routes for creation-fields and update-fields
+        return preg_match('/nova-api\/[^\/]+(?:\/\d+)?\/(?:creation-fields|update-fields)/', $path) === 1;
+    }
+
+    /**
+     * Check if the request contains flexible content field names.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return bool
+     */
+    protected function hasFlexibleFieldNames(Request $request): bool
+    {
+        // Check if the 'field' parameter or any input contains the flexible group separator
+        $field = $request->get('field');
+
+        if ($field && strpos($field, FlexibleAttribute::GROUP_SEPARATOR) !== false) {
+            return true;
+        }
+
+        foreach ($request->all() as $key => $value) {
+            if (strpos($key, FlexibleAttribute::GROUP_SEPARATOR) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Transform flexible field names by stripping the group key prefix.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function transformFlexibleFieldNames(Request $request): void
+    {
+        // Transform the 'field' query parameter if present
+        $field = $request->get('field');
+
+        if ($field && strpos($field, FlexibleAttribute::GROUP_SEPARATOR) !== false) {
+            $transformedField = $this->stripGroupPrefix($field);
+            $request->query->set('field', $transformedField);
+        }
+
+        // Transform all input field names
+        $transformedInput = $this->transformInputFields($request->all());
+
+        if (! empty($transformedInput)) {
+            $request->merge($transformedInput);
+        }
+    }
+
+    /**
+     * Transform input fields by stripping flexible group prefixes.
+     *
+     * @param  array  $input
+     * @return array
+     */
+    protected function transformInputFields(array $input): array
+    {
+        $transformed = [];
+
+        foreach ($input as $key => $value) {
+            if (strpos($key, FlexibleAttribute::GROUP_SEPARATOR) !== false) {
+                $newKey = $this->stripGroupPrefix($key);
+                $transformed[$newKey] = $value;
+            }
+        }
+
+        return $transformed;
+    }
+
+    /**
+     * Strip the flexible group prefix from a field name.
+     *
+     * @param  string  $fieldName
+     * @return string
+     */
+    protected function stripGroupPrefix(string $fieldName): string
+    {
+        $separatorPosition = strpos($fieldName, FlexibleAttribute::GROUP_SEPARATOR);
+
+        if ($separatorPosition === false) {
+            return $fieldName;
+        }
+
+        return substr($fieldName, $separatorPosition + strlen(FlexibleAttribute::GROUP_SEPARATOR));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds proper support for Nova's `dependsOn` functionality inside flexible content layouts by introducing a new middleware that transforms field names in dependent field requests.

## Problem

When using `dependsOn` on fields inside a Flexible layout, the callbacks don't receive the expected field names. This is because:

1. Flexible content prefixes field names with a unique group key (e.g., `ckOi67sYIRR0L6kh__product`)
2. When Nova makes AJAX requests to `creation-fields` or `update-fields` endpoints for dependent fields, it sends these prefixed names
3. The `dependsOn` callback expects the original field names (e.g., `product`)

## Solution

Added a new middleware `InterceptFlexibleDependsOnAttributes` that:

- Intercepts Nova's dependent field API requests (`creation-fields` and `update-fields`)
- Detects if the request contains flexible content prefixed field names
- Transforms the `field` query parameter by stripping the group prefix
- Transforms input field names by stripping the group prefix

This allows the `dependsOn` callbacks to work correctly inside flexible layouts.

## Usage Example

```php
Flexible::make('Order items')
    ->addLayout('Select Products', 'product', [
        Select::make('Product')
            ->options(Product::all()->pluck('name', 'id'))
            ->displayUsingLabels()
            ->searchable(),
        Text::make('Price')
            ->dependsOn(['product'], function (Text $field, NovaRequest $request, FormData $formData) {
                if ($formData->product) {
                    $product = Product::find($formData->product);
                    $field->withMeta(['value' => $product->price]);
                }
            }),
    ])
```

## Files Changed

- `src/Http/Middleware/InterceptFlexibleDependsOnAttributes.php` - New middleware for handling dependsOn requests
- `src/FieldServiceProvider.php` - Register the new middleware

## Technical Details

The middleware uses the existing `FlexibleAttribute::GROUP_SEPARATOR` constant (`__`) to detect and strip group prefixes from field names. It only processes requests that match Nova's dependent field API routes.

Fixes #524