### PR TITLE
prevent delete preserving media

### DIFF
--- a/src/Concerns/HasMediaLibrary.php
+++ b/src/Concerns/HasMediaLibrary.php
@@ -142,7 +142,7 @@ trait HasMediaLibrary
      */
     protected function removeCallback(Flexible $flexible, $layout)
     {
-        if ($this->shouldDeletePreservingMedia()) {
+        if (!$this->shouldDeletePreservingMedia()) {
             return;
         }
 


### PR DESCRIPTION
removeCallback should delete the preserving media only if shouldDeletePreservingMedia returns true.
However, in this case, deletePreservingMedia is **false**, which is correct.
The problem is that removeCallback still deletes the preserving media because the condition is reversed.